### PR TITLE
[feat] 콘텐츠 CRUD 구현

### DIFF
--- a/src/main/java/com/mopl/api/domain/content/controller/ContentController.java
+++ b/src/main/java/com/mopl/api/domain/content/controller/ContentController.java
@@ -11,14 +11,14 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -45,22 +45,25 @@ public class ContentController {
     }
 
     @PostMapping
-    public ResponseEntity<ContentDto> contentAdd(@Valid @RequestBody ContentCreateRequest request,
-        @RequestParam MultipartFile file) {
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<ContentDto> contentAdd(@Valid @RequestPart ContentCreateRequest request,
+        @RequestPart MultipartFile file) {
         ContentDto contentDto = contentService.addContent(request, file);
         return ResponseEntity.status(HttpStatus.CREATED)
                              .body(contentDto);
     }
 
     @PatchMapping("/{contentId}")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<ContentDto> contentModify(@PathVariable UUID contentId,
-        @Valid @RequestBody ContentUpdateRequest request, @RequestParam(required = false) MultipartFile file) {
+        @Valid @RequestPart ContentUpdateRequest request, @RequestPart(required = false) MultipartFile file) {
         ContentDto contentDto = contentService.modifyContent(contentId, request, file);
         return ResponseEntity.status(HttpStatus.OK)
                              .body(contentDto);
     }
 
     @DeleteMapping("/{contentId}")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<ContentDto> contentRemove(@PathVariable UUID contentId) {
         contentService.removeContent(contentId);
         return ResponseEntity.status(HttpStatus.NO_CONTENT)

--- a/src/main/java/com/mopl/api/domain/content/entity/Content.java
+++ b/src/main/java/com/mopl/api/domain/content/entity/Content.java
@@ -52,4 +52,23 @@ public class Content extends BaseDeletableEntity {
 
     @Column(nullable = false)
     private Long watcherCount = 0L;
+
+    public void update(String title, String description, String tags, String thumbnailUrl) {
+        if (title != null && !title.isBlank()) {
+            this.title = title;
+        }
+        if (description != null && !description.isBlank()) {
+            this.description = description;
+        }
+        if (tags != null && !tags.isBlank()) {
+            this.tags = tags;
+        }
+        if (thumbnailUrl != null && !thumbnailUrl.isBlank()) {
+            this.thumbnailUrl = thumbnailUrl;
+        }
+    }
+
+    public void isDelete() {
+        this.isDeleted = true;
+    }
 }

--- a/src/main/java/com/mopl/api/domain/content/mapper/ContentMapper.java
+++ b/src/main/java/com/mopl/api/domain/content/mapper/ContentMapper.java
@@ -1,0 +1,14 @@
+package com.mopl.api.domain.content.mapper;
+
+import com.mopl.api.domain.content.dto.response.ContentDto;
+import com.mopl.api.domain.content.entity.Content;
+import java.util.Arrays;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring", imports = {Arrays.class})
+public interface ContentMapper {
+
+    @Mapping(target = "tags", expression = "java(Arrays.asList(content.getTags().split(\"\\\\|\")))")
+    ContentDto toDto(Content content);
+}

--- a/src/main/java/com/mopl/api/domain/content/repository/ContentRepository.java
+++ b/src/main/java/com/mopl/api/domain/content/repository/ContentRepository.java
@@ -1,6 +1,7 @@
 package com.mopl.api.domain.content.repository;
 
 import com.mopl.api.domain.content.entity.Content;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -8,4 +9,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ContentRepository extends JpaRepository<Content, UUID> {
 
+    Optional<Content> findByIdAndIsDeletedFalse(UUID id);
 }

--- a/src/main/java/com/mopl/api/domain/content/service/ContentServiceImpl.java
+++ b/src/main/java/com/mopl/api/domain/content/service/ContentServiceImpl.java
@@ -5,10 +5,17 @@ import com.mopl.api.domain.content.dto.request.ContentSearchRequest;
 import com.mopl.api.domain.content.dto.request.ContentUpdateRequest;
 import com.mopl.api.domain.content.dto.response.ContentDto;
 import com.mopl.api.domain.content.dto.response.CursorResponseContentDto;
+import com.mopl.api.domain.content.entity.Content;
+import com.mopl.api.domain.content.mapper.ContentMapper;
 import com.mopl.api.domain.content.repository.ContentRepository;
+import com.mopl.api.global.config.image.LocalUploader;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
@@ -16,28 +23,69 @@ import org.springframework.web.multipart.MultipartFile;
 public class ContentServiceImpl implements ContentService {
 
     private final ContentRepository contentRepository;
+    private final ContentMapper contentMapper;
+    private final LocalUploader localUploader;
 
     @Override
+    @Transactional(readOnly = true)
     public ContentDto getContent(UUID id) {
-        return null;
+        Content content = contentRepository.findByIdAndIsDeletedFalse(id)
+                                           .orElseThrow(
+                                               () -> new NoSuchElementException("Content not found with id: " + id));
+        return contentMapper.toDto(content);
     }
 
     @Override
+    @Transactional(readOnly = true)
     public CursorResponseContentDto getContents(ContentSearchRequest request) {
         return null;
     }
 
     @Override
+    @Transactional
     public ContentDto addContent(ContentCreateRequest request, MultipartFile file) {
-        return null;
+        String tags = tagToString(request.tags());
+
+        String thumbnail = localUploader.upload(file);
+
+        Content content = new Content(request.type(), null, request.title(), request.description(),
+            thumbnail, tags, BigDecimal.ZERO, 0L, 0L);
+
+        return contentMapper.toDto(contentRepository.save(content));
     }
 
     @Override
+    @Transactional
     public ContentDto modifyContent(UUID id, ContentUpdateRequest request, MultipartFile file) {
-        return null;
+        Content content = contentRepository.findByIdAndIsDeletedFalse(id)
+                                           .orElseThrow(
+                                               () -> new NoSuchElementException("Content not found with id: " + id));
+
+        String thumbnail = null;
+        String tags = tagToString(request.tags());
+
+        if (file != null && !file.isEmpty()) {
+            thumbnail = localUploader.upload(file);
+        }
+
+        content.update(request.title(), request.description(), tags, thumbnail);
+
+        return contentMapper.toDto(content);
     }
 
     @Override
+    @Transactional
     public void removeContent(UUID id) {
+        Content content = contentRepository.findByIdAndIsDeletedFalse(id)
+                                           .orElseThrow(
+                                               () -> new NoSuchElementException("Content not found with id: " + id));
+        content.isDelete();
+    }
+
+    private String tagToString(List<String> tagList) {
+        if (tagList == null || tagList.isEmpty()) {
+            return null;
+        }
+        return String.join("|", tagList);
     }
 }

--- a/src/main/java/com/mopl/api/global/config/image/LocalUploader.java
+++ b/src/main/java/com/mopl/api/global/config/image/LocalUploader.java
@@ -1,0 +1,36 @@
+package com.mopl.api.global.config.image;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@Component
+public class LocalUploader {
+
+    private final String UPLOAD_DIR = "src/main/resources/static/contents";
+
+    public String upload(MultipartFile file) {
+        try {
+            File dir = new File(UPLOAD_DIR);
+
+            if (!dir.exists()) {
+                dir.mkdirs();
+            }
+
+            String fileName = UUID.randomUUID() + file.getOriginalFilename();
+
+            Path path = Paths.get(UPLOAD_DIR + "/" + fileName);
+
+            Files.copy(file.getInputStream(), path);
+
+            return "/contents/" + fileName;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
## Issues
- closed #32 

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description
- 콘텐츠 기본 CURD 구현
- 이미지 로컬 저장 컴포넌트 추가
## 📷 Screenshot
- 콘텐츠 생성
<img width="1452" height="1085" alt="image" src="https://github.com/user-attachments/assets/e3f065f5-fcc9-45de-925f-a673946fe9b5" />

- 콘텐츠 수정
<img width="1449" height="1072" alt="image" src="https://github.com/user-attachments/assets/b2270459-270c-4126-bcbd-f4ced5df0df1" />


- 콘텐츠 조회
<img width="1398" height="1084" alt="image" src="https://github.com/user-attachments/assets/8976caae-d38f-45c2-aa55-f42823a5f50c" />


- 콘텐츠 삭제
<img width="1425" height="757" alt="image" src="https://github.com/user-attachments/assets/ae070613-e211-4c11-8ea5-fa96fe02bf1d" />


## 📚 Reference

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 콘텐츠 생성, 수정, 삭제 작업에 관리자 권한 제한 추가
  * 파일 업로드 기능 및 멀티파트 요청 지원 추가
  * 콘텐츠 소프트 삭제 기능 구현

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->