### PR TITLE
[feat] TMDB/SprotsDB API 연동

### DIFF
--- a/src/main/java/com/mopl/api/global/client/sportdb/ThesportdbApiClient.java
+++ b/src/main/java/com/mopl/api/global/client/sportdb/ThesportdbApiClient.java
@@ -1,0 +1,44 @@
+package com.mopl.api.global.client.sportdb;
+
+import com.mopl.api.global.client.sportdb.response.EventsResponse;
+import com.mopl.api.global.client.sportdb.response.SportResponse;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Slf4j
+@Component
+public class ThesportdbApiClient {
+
+    @Value("${thesportdb.api-key}")
+    private String apiKey;
+
+    private final RestClient restClient;
+
+    public ThesportdbApiClient(RestClient.Builder builder) {
+        this.restClient = builder
+            .baseUrl("https://www.thesportsdb.com/api/v1/json")
+            .build();
+    }
+
+    public List<SportResponse> getSportDetails(String date) {
+        try {
+            EventsResponse events = restClient.get()
+                               .uri(uriBuilder ->
+                                   uriBuilder.path("/" + apiKey + "/eventsday.php")
+                                             .queryParam("d", date)
+                                             .queryParam("s", "soccer")
+                                             .queryParam("language", "en-En")
+                                             .build()
+                               )
+                               .retrieve()
+                               .body(EventsResponse.class);
+            return events != null ? events.events() : List.of();
+        } catch (Exception e) {
+            log.warn("Failed to fetch events from TheSportsDB for date=" + date, e);
+            return List.of();
+        }
+    }
+}

--- a/src/main/java/com/mopl/api/global/client/sportdb/response/EventsResponse.java
+++ b/src/main/java/com/mopl/api/global/client/sportdb/response/EventsResponse.java
@@ -1,0 +1,9 @@
+package com.mopl.api.global.client.sportdb.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public record EventsResponse(
+    @JsonProperty("events")
+    List<SportResponse> events
+) {}

--- a/src/main/java/com/mopl/api/global/client/sportdb/response/SportResponse.java
+++ b/src/main/java/com/mopl/api/global/client/sportdb/response/SportResponse.java
@@ -1,0 +1,28 @@
+package com.mopl.api.global.client.sportdb.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record SportResponse(
+    @JsonProperty("idEvent")
+    Long apiId,
+
+    @JsonProperty("strEvent")
+    String title,
+
+    @JsonProperty("strFilename")
+    String description,
+
+    @JsonProperty("strThumb")
+    String thumbnailUrl,
+
+    @JsonProperty("strSport")
+    String sport,
+
+    @JsonProperty("strVenue")
+    String venue
+) {
+
+    public String getTags() {
+        return sport + "|" + venue;
+    }
+}

--- a/src/main/java/com/mopl/api/global/client/tmdb/TmdbApiClient.java
+++ b/src/main/java/com/mopl/api/global/client/tmdb/TmdbApiClient.java
@@ -1,0 +1,103 @@
+package com.mopl.api.global.client.tmdb;
+
+import com.mopl.api.global.client.tmdb.response.Genre;
+import com.mopl.api.global.client.tmdb.response.GenreResponse;
+import com.mopl.api.global.client.tmdb.response.MovieResponse;
+import com.mopl.api.global.client.tmdb.response.PopularMovieResponse;
+import com.mopl.api.global.client.tmdb.response.PopularTvSeriesResponse;
+import com.mopl.api.global.client.tmdb.response.TvSeriesResponse;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Slf4j
+@Component
+public class TmdbApiClient {
+
+    @Value("${tmdb.api-key}")
+    private String apiKey;
+
+    private final RestClient restClient;
+
+    public TmdbApiClient(RestClient.Builder builder) {
+        this.restClient = builder
+            .baseUrl("https://api.themoviedb.org/3")
+            .build();
+    }
+
+    public List<MovieResponse> getMovieDetails(Long page) {
+        try {
+            PopularMovieResponse popularMovies = restClient.get()
+                                                           .uri(uriBuilder ->
+                                                               uriBuilder.path("/movie/popular")
+                                                                         .queryParam("page", page)
+                                                                         .queryParam("api_key", apiKey)
+                                                                         .queryParam("language", "ko-KR")
+                                                                         .build()
+                                                           )
+                                                           .retrieve()
+                                                           .body(PopularMovieResponse.class);
+            return popularMovies != null ? popularMovies.movies() : List.of();
+        } catch (Exception e) {
+            log.warn("Failed to fetch movie from TMDB for page=" + page, e);
+            return List.of();
+        }
+    }
+
+    public List<Genre> getMovieGenres() {
+        try {
+            GenreResponse genres = restClient.get()
+                                             .uri(uriBuilder ->
+                                                 uriBuilder.path("/genre/movie/list")
+                                                           .queryParam("api_key", apiKey)
+                                                           .queryParam("language", "ko-KR")
+                                                           .build()
+                                             )
+                                             .retrieve()
+                                             .body(GenreResponse.class);
+            return genres != null ? genres.genres() : List.of();
+        } catch (Exception e) {
+            log.warn("Failed to fetch movie from TMDB for genre=", e);
+            return List.of();
+        }
+    }
+
+    public List<TvSeriesResponse> getTvSeriesDetails(Long page) {
+        try {
+            PopularTvSeriesResponse popularTvSeries = restClient.get()
+                                                                .uri(uriBuilder ->
+                                                                    uriBuilder.path("/tv/popular")
+                                                                              .queryParam("page", page)
+                                                                              .queryParam("api_key", apiKey)
+                                                                              .queryParam("language", "ko-KR")
+                                                                              .build()
+                                                                )
+                                                                .retrieve()
+                                                                .body(PopularTvSeriesResponse.class);
+            return popularTvSeries != null ? popularTvSeries.tvSeries() : List.of();
+        } catch (Exception e) {
+            log.warn("Failed to fetch tvSeries from TMDB for page=" + page, e);
+            return List.of();
+        }
+    }
+
+    public List<Genre> getTvGenres() {
+        try {
+            GenreResponse genres = restClient.get()
+                                             .uri(uriBuilder ->
+                                                 uriBuilder.path("/genre/tv/list")
+                                                           .queryParam("api_key", apiKey)
+                                                           .queryParam("language", "ko-KR")
+                                                           .build()
+                                             )
+                                             .retrieve()
+                                             .body(GenreResponse.class);
+            return genres != null ? genres.genres() : List.of();
+        } catch (Exception e) {
+            log.warn("Failed to fetch movie from TMDB for genre=", e);
+            return List.of();
+        }
+    }
+}

--- a/src/main/java/com/mopl/api/global/client/tmdb/response/Genre.java
+++ b/src/main/java/com/mopl/api/global/client/tmdb/response/Genre.java
@@ -1,0 +1,10 @@
+package com.mopl.api.global.client.tmdb.response;
+
+import lombok.Getter;
+
+@Getter
+public class Genre {
+
+    private Long id;
+    private String name;
+}

--- a/src/main/java/com/mopl/api/global/client/tmdb/response/GenreResponse.java
+++ b/src/main/java/com/mopl/api/global/client/tmdb/response/GenreResponse.java
@@ -1,0 +1,9 @@
+package com.mopl.api.global.client.tmdb.response;
+
+import java.util.List;
+
+public record GenreResponse(
+     List<Genre> genres
+) {
+
+}

--- a/src/main/java/com/mopl/api/global/client/tmdb/response/MovieResponse.java
+++ b/src/main/java/com/mopl/api/global/client/tmdb/response/MovieResponse.java
@@ -2,7 +2,6 @@ package com.mopl.api.global.client.tmdb.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public record MovieResponse(
     @JsonProperty("id")
@@ -17,17 +16,11 @@ public record MovieResponse(
     @JsonProperty("poster_path")
     String thumbnailUrl,
 
-    @JsonProperty("genres")
-    List<TagDto> tags
+    @JsonProperty("genre_ids")
+    List<Long> tags
 ) {
 
     public MovieResponse {
         thumbnailUrl = thumbnailUrl == null ? null : "https://image.tmdb.org/t/p/w500" + thumbnailUrl;
-    }
-
-    public String getTag() {
-        return tags == null ? null : tags.stream()
-                                         .map(TagDto::name)
-                                         .collect(Collectors.joining("|"));
     }
 }

--- a/src/main/java/com/mopl/api/global/client/tmdb/response/MovieResponse.java
+++ b/src/main/java/com/mopl/api/global/client/tmdb/response/MovieResponse.java
@@ -1,0 +1,33 @@
+package com.mopl.api.global.client.tmdb.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record MovieResponse(
+    @JsonProperty("id")
+    Long apiId,
+
+    @JsonProperty("original_name")
+    String title,
+
+    @JsonProperty("overview")
+    String description,
+
+    @JsonProperty("poster_path")
+    String thumbnailUrl,
+
+    @JsonProperty("genres")
+    List<TagDto> tags
+) {
+
+    public MovieResponse {
+        thumbnailUrl = thumbnailUrl == null ? null : "https://image.tmdb.org/t/p/w500" + thumbnailUrl;
+    }
+
+    public String getTag() {
+        return tags == null ? null : tags.stream()
+                                         .map(TagDto::name)
+                                         .collect(Collectors.joining("|"));
+    }
+}

--- a/src/main/java/com/mopl/api/global/client/tmdb/response/MovieResponse.java
+++ b/src/main/java/com/mopl/api/global/client/tmdb/response/MovieResponse.java
@@ -8,7 +8,7 @@ public record MovieResponse(
     @JsonProperty("id")
     Long apiId,
 
-    @JsonProperty("original_name")
+    @JsonProperty("original_title")
     String title,
 
     @JsonProperty("overview")

--- a/src/main/java/com/mopl/api/global/client/tmdb/response/PopularMovieResponse.java
+++ b/src/main/java/com/mopl/api/global/client/tmdb/response/PopularMovieResponse.java
@@ -1,0 +1,11 @@
+package com.mopl.api.global.client.tmdb.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public record PopularMovieResponse(
+    @JsonProperty("results")
+    List<MovieResponse> movies
+) {
+
+}

--- a/src/main/java/com/mopl/api/global/client/tmdb/response/PopularTvSeriesResponse.java
+++ b/src/main/java/com/mopl/api/global/client/tmdb/response/PopularTvSeriesResponse.java
@@ -1,0 +1,11 @@
+package com.mopl.api.global.client.tmdb.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+public record PopularTvSeriesResponse(
+    @JsonProperty("results")
+    List<TvSeriesResponse> tvSeries
+) {
+
+}

--- a/src/main/java/com/mopl/api/global/client/tmdb/response/TagDto.java
+++ b/src/main/java/com/mopl/api/global/client/tmdb/response/TagDto.java
@@ -1,8 +1,0 @@
-package com.mopl.api.global.client.tmdb.response;
-
-public record TagDto(
-    Long id,
-    String name
-) {
-
-}

--- a/src/main/java/com/mopl/api/global/client/tmdb/response/TagDto.java
+++ b/src/main/java/com/mopl/api/global/client/tmdb/response/TagDto.java
@@ -1,0 +1,8 @@
+package com.mopl.api.global.client.tmdb.response;
+
+public record TagDto(
+    Long id,
+    String name
+) {
+
+}

--- a/src/main/java/com/mopl/api/global/client/tmdb/response/TvSeriesResponse.java
+++ b/src/main/java/com/mopl/api/global/client/tmdb/response/TvSeriesResponse.java
@@ -1,0 +1,33 @@
+package com.mopl.api.global.client.tmdb.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record TvSeriesResponse(
+    @JsonProperty("id")
+    Long apiId,
+
+    @JsonProperty("original_name")
+    String title,
+
+    @JsonProperty("overview")
+    String description,
+
+    @JsonProperty("poster_path")
+    String thumbnailUrl,
+
+    @JsonProperty("genres")
+    List<TagDto> tags
+) {
+
+    public TvSeriesResponse {
+        thumbnailUrl = thumbnailUrl == null ? null : "https://image.tmdb.org/t/p/w500" + thumbnailUrl;
+    }
+
+    public String getTag() {
+        return tags == null ? null : tags.stream()
+                                         .map(TagDto::name)
+                                         .collect(Collectors.joining("|"));
+    }
+}

--- a/src/main/java/com/mopl/api/global/client/tmdb/response/TvSeriesResponse.java
+++ b/src/main/java/com/mopl/api/global/client/tmdb/response/TvSeriesResponse.java
@@ -2,7 +2,6 @@ package com.mopl.api.global.client.tmdb.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public record TvSeriesResponse(
     @JsonProperty("id")
@@ -17,17 +16,11 @@ public record TvSeriesResponse(
     @JsonProperty("poster_path")
     String thumbnailUrl,
 
-    @JsonProperty("genres")
-    List<TagDto> tags
+    @JsonProperty("genre_ids")
+    List<Long> tags
 ) {
 
     public TvSeriesResponse {
         thumbnailUrl = thumbnailUrl == null ? null : "https://image.tmdb.org/t/p/w500" + thumbnailUrl;
-    }
-
-    public String getTag() {
-        return tags == null ? null : tags.stream()
-                                         .map(TagDto::name)
-                                         .collect(Collectors.joining("|"));
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -83,3 +83,7 @@ custom:
     refresh-token:
       secret: ${JWT_REFRESH_SECRET:refresh-secret-key-even-longer-and-more-random}
       expiration-ms: ${JWT_REFRESH_EXPIRATION_MS:1209600000}  # 14일
+tmdb:
+  api-key: ${TMDB_API_KEY:needKey}
+thesportdb:
+  api-key: ${THE_SPORT_API_KEY:needKey}


### PR DESCRIPTION
## Issues
- closed #45 

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description
- TMDB/SprotsDB Client 구현
## 📷 Screenshot

## 📚 Reference
- tmdb 데이터는 인기 리스트에서 page를 기준으로 가져옴
- Sprots DB 데이터는 경기 리스트에서 날짜를 기준으로 축구 정보를 가져옴
- tmdb에서 장르를 id로 가져와 장르를 저장할 데이터베이스 생성이 필요하다고 생각됨 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 날짜별 스포츠 이벤트 조회 기능 추가
  * 인기 영화 정보 조회 기능 추가 — 제목, 설명, 포스터 이미지 포함
  * 인기 TV 시리즈 정보 조회 기능 추가
  * 영화 및 TV 시리즈 장르 카테고리 지원
  * 응답 이미지 URL 정규화 및 항목별 태그 정보 제공

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->