### PR TITLE
[hotfix] websocket 인증 및 유저 정보 세팅 보완

### DIFF
--- a/src/main/java/com/mopl/api/global/config/websocket/WebSocketAuthChannelInterceptor.java
+++ b/src/main/java/com/mopl/api/global/config/websocket/WebSocketAuthChannelInterceptor.java
@@ -8,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
@@ -27,28 +28,22 @@ public class WebSocketAuthChannelInterceptor implements ChannelInterceptor {
 
         if (accessor != null && StompCommand.CONNECT.equals(accessor.getCommand())) {
             String authHeader = accessor.getFirstNativeHeader("Authorization");
+            if (authHeader != null && authHeader.startsWith("Bearer ")) {
+                try {
+                    String token = authHeader.substring(7);
+                    UUID userId = jwtTokenProvider.getUserIdFromToken(token);
 
-            if (authHeader == null || !authHeader.startsWith("Bearer ")) {
-                log.error("웹소켓 연결 실패: Authorization 헤더가 없거나 잘못되었습니다.");
-                return message;
-            }
+                    Authentication authentication = new UsernamePasswordAuthenticationToken(
+                        userId.toString(), null, List.of());
 
-            String token = authHeader.substring(7);
-
-            try {
-                UUID userId = jwtTokenProvider.getUserIdFromToken(token);
-
-                Authentication authentication = new UsernamePasswordAuthenticationToken(
-                    userId.toString(),
-                    null,
-                    List.of()
-                );
-
-                accessor.setUser(authentication);
-                log.info("웹소켓 인증 성공: 유저 ID = {}", userId);
-
-            } catch (Exception e) {
-                log.error("웹소켓 인증 실패: {}", e.getMessage());
+                    accessor.setUser(authentication);
+                } catch (Exception e) {
+                    log.error("웹소켓 인증 실패: {}", e.getMessage());
+                    throw new MessageDeliveryException("인증 실패");
+                }
+            } else {
+                log.error("Authorization 헤더가 없습니다.");
+                throw new MessageDeliveryException("헤더 누락");
             }
         }
 

--- a/src/main/java/com/mopl/api/global/config/websocket/WebSocketAuthChannelInterceptor.java
+++ b/src/main/java/com/mopl/api/global/config/websocket/WebSocketAuthChannelInterceptor.java
@@ -4,15 +4,18 @@ import com.mopl.api.global.config.security.jwt.JwtTokenProvider;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 
+@Slf4j
 @RequiredArgsConstructor
 public class WebSocketAuthChannelInterceptor implements ChannelInterceptor {
 
@@ -20,27 +23,33 @@ public class WebSocketAuthChannelInterceptor implements ChannelInterceptor {
 
     @Override
     public Message<?> preSend(@NotNull Message<?> message, @NotNull MessageChannel channel) {
-        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
 
-        if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+        if (accessor != null && StompCommand.CONNECT.equals(accessor.getCommand())) {
             String authHeader = accessor.getFirstNativeHeader("Authorization");
 
             if (authHeader == null || !authHeader.startsWith("Bearer ")) {
-                throw new IllegalArgumentException("Missing Authorization header");
+                log.error("웹소켓 연결 실패: Authorization 헤더가 없거나 잘못되었습니다.");
+                return message;
             }
 
             String token = authHeader.substring(7);
 
-            UUID userId = jwtTokenProvider.getUserIdFromToken(token);
+            try {
+                UUID userId = jwtTokenProvider.getUserIdFromToken(token);
 
-            Authentication authentication =
-                new UsernamePasswordAuthenticationToken(
+                Authentication authentication = new UsernamePasswordAuthenticationToken(
                     userId.toString(),
                     null,
                     List.of()
                 );
 
-            accessor.setUser(authentication);
+                accessor.setUser(authentication);
+                log.info("웹소켓 인증 성공: 유저 ID = {}", userId);
+
+            } catch (Exception e) {
+                log.error("웹소켓 인증 실패: {}", e.getMessage());
+            }
         }
 
         return message;


### PR DESCRIPTION
## Issues
- #60 

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description

## 📷 Screenshot

## 📚 Reference

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * WebSocket 인증 시 Authorization 헤더가 누락되거나 유효하지 않을 때 명확한 오류 응답(전송 예외)을 반환하도록 처리했습니다.
  * 토큰 파싱/검증 실패 시 실패를 로깅하고 적절한 예외로 반환하도록 개선했습니다.

* **개선사항**
  * 인증 시도 및 결과에 대한 상세 로깅이 추가되어 문제 원인 파악이 쉬워졌습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->