### PR TITLE
[fix] 콘텐츠 평점 재계산 기능 수정

### DIFF
--- a/src/main/java/com/mopl/api/domain/review/repository/impl/ReviewRepositoryCustom.java
+++ b/src/main/java/com/mopl/api/domain/review/repository/impl/ReviewRepositoryCustom.java
@@ -19,4 +19,6 @@ public interface ReviewRepositoryCustom {
     );
 
     long countReviewsByContentId(UUID contentId);
+
+    List<Review> findActiveReviewsByContentId(UUID contentId);
 }

--- a/src/main/java/com/mopl/api/domain/review/repository/impl/ReviewRepositoryImpl.java
+++ b/src/main/java/com/mopl/api/domain/review/repository/impl/ReviewRepositoryImpl.java
@@ -73,6 +73,15 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
             .fetchCount();
     }
 
+    @Override
+    public List<Review> findActiveReviewsByContentId(UUID contentId) {
+        return queryFactory
+            .selectFrom(review)
+            .where(review.content.id.eq(contentId)
+                .and(review.isDeleted.eq(false)))
+            .fetch();
+    }
+
     private BooleanExpression buildCursorPredicate(
         String sortBy,
         String sortDirection,

--- a/src/main/java/com/mopl/api/domain/review/service/ReviewService.java
+++ b/src/main/java/com/mopl/api/domain/review/service/ReviewService.java
@@ -186,19 +186,14 @@ public class ReviewService {
         Content content = contentRepository.findById(contentId)
                                            .orElseThrow(() -> ContentNotFoundException.withContentId(contentId));
 
-        List<Review> activeReviews = reviewRepository.findAll()
-                                                     .stream()
-                                                     .filter(r -> r.getContent()
-                                                                   .getId()
-                                                                   .equals(contentId) && !r.getIsDeleted())
-                                                     .toList();
+        List<Review> activeReviews = reviewRepository.findActiveReviewsByContentId(contentId);
 
         if (activeReviews.isEmpty()) {
             content.updateRatingStats(BigDecimal.ZERO, 0L);
         } else {
             BigDecimal sum = activeReviews.stream()
                                           .map(Review::getRating)
-                                          .reduce(BigDecimal.ZERO, BigDecimal::add); // 초기값 0.0, 누적 덧셈
+                                          .reduce(BigDecimal.ZERO, BigDecimal::add);
 
             BigDecimal average = sum.divide(BigDecimal.valueOf(activeReviews.size()), 1, RoundingMode.HALF_UP);
 

--- a/src/test/java/com/mopl/api/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/mopl/api/domain/review/service/ReviewServiceTest.java
@@ -127,7 +127,7 @@ class ReviewServiceTest {
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         when(reviewRepository.existsByContentIdAndUserIdAndIsDeletedFalse(contentId, userId)).thenReturn(false);
         when(reviewRepository.save(any(Review.class))).thenReturn(review);
-        when(reviewRepository.findAll()).thenReturn(List.of(review));
+        when(reviewRepository.findActiveReviewsByContentId(contentId)).thenReturn(List.of(review));
         when(reviewMapper.toDto(any(Review.class), eq(true))).thenReturn(expectedDto);
 
         ReviewDto result = reviewService.addReview(request, userId);
@@ -241,7 +241,7 @@ class ReviewServiceTest {
 
         when(reviewRepository.findById(reviewId)).thenReturn(Optional.of(review));
         when(reviewRepository.save(review)).thenReturn(review);
-        when(reviewRepository.findAll()).thenReturn(List.of(review));
+        when(reviewRepository.findActiveReviewsByContentId(contentId)).thenReturn(List.of(review));
         when(contentRepository.findById(contentId)).thenReturn(Optional.of(content));
         when(reviewMapper.toDto(review, true)).thenReturn(expectedDto);
 
@@ -314,7 +314,7 @@ class ReviewServiceTest {
 
         when(reviewRepository.findById(reviewId)).thenReturn(Optional.of(review));
         when(reviewRepository.save(review)).thenReturn(review);
-        when(reviewRepository.findAll()).thenReturn(List.of());
+        when(reviewRepository.findActiveReviewsByContentId(contentId)).thenReturn(List.of());
         when(contentRepository.findById(contentId)).thenReturn(Optional.of(content));
 
         reviewService.removeReview(reviewId, userId);
@@ -589,7 +589,7 @@ class ReviewServiceTest {
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         when(reviewRepository.existsByContentIdAndUserIdAndIsDeletedFalse(contentId, userId)).thenReturn(false);
         when(reviewRepository.save(any(Review.class))).thenReturn(review);
-        when(reviewRepository.findAll()).thenReturn(List.of(review));
+        when(reviewRepository.findActiveReviewsByContentId(contentId)).thenReturn(List.of(review));
         when(reviewMapper.toDto(any(Review.class), eq(true))).thenReturn(expectedDto);
 
         reviewService.addReview(request, userId);
@@ -634,7 +634,7 @@ class ReviewServiceTest {
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         when(reviewRepository.existsByContentIdAndUserIdAndIsDeletedFalse(contentId, userId)).thenReturn(false);
         when(reviewRepository.save(any(Review.class))).thenReturn(newReview);
-        when(reviewRepository.findAll()).thenReturn(List.of(existingReview1, existingReview2, newReview));
+        when(reviewRepository.findActiveReviewsByContentId(contentId)).thenReturn(List.of(newReview, existingReview1, existingReview2));
         when(reviewMapper.toDto(any(Review.class), eq(true))).thenReturn(expectedDto);
 
         reviewService.addReview(request, userId);
@@ -673,7 +673,7 @@ class ReviewServiceTest {
 
         when(reviewRepository.findById(reviewId)).thenReturn(Optional.of(review));
         when(reviewRepository.save(review)).thenReturn(review);
-        when(reviewRepository.findAll()).thenReturn(List.of(review, existingReview));
+        when(reviewRepository.findActiveReviewsByContentId(contentId)).thenReturn(List.of(review, existingReview));
         when(contentRepository.findById(contentId)).thenReturn(Optional.of(content));
         when(reviewMapper.toDto(review, true)).thenReturn(expectedDto);
 
@@ -697,6 +697,7 @@ class ReviewServiceTest {
             .set("id", reviewId)
             .set("user", user)
             .set("content", content)
+            .set("rating", BigDecimal.valueOf(5.0))
             .set("isDeleted", false)
             .sample();
         
@@ -708,7 +709,7 @@ class ReviewServiceTest {
 
         when(reviewRepository.findById(reviewId)).thenReturn(Optional.of(review));
         when(reviewRepository.save(review)).thenReturn(review);
-        when(reviewRepository.findAll()).thenReturn(List.of(review, remainingReview));
+        when(reviewRepository.findActiveReviewsByContentId(contentId)).thenReturn(List.of(remainingReview));
         when(contentRepository.findById(contentId)).thenReturn(Optional.of(content));
 
         reviewService.removeReview(reviewId, userId);
@@ -731,12 +732,13 @@ class ReviewServiceTest {
             .set("id", reviewId)
             .set("user", user)
             .set("content", content)
+            .set("rating", BigDecimal.valueOf(5.0))
             .set("isDeleted", false)
             .sample();
 
         when(reviewRepository.findById(reviewId)).thenReturn(Optional.of(review));
         when(reviewRepository.save(review)).thenReturn(review);
-        when(reviewRepository.findAll()).thenReturn(List.of(review));
+        when(reviewRepository.findActiveReviewsByContentId(contentId)).thenReturn(List.of());
         when(contentRepository.findById(contentId)).thenReturn(Optional.of(content));
 
         reviewService.removeReview(reviewId, userId);


### PR DESCRIPTION
## Issues
- closed #134 

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description

## 📷 Screenshot

## 📚 Reference

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 특정 콘텐츠 ID에 대해 삭제되지 않은 활성 리뷰만 조회하는 새 API가 추가되었습니다. 콘텐츠별 유효한 리뷰 목록을 직접 가져올 수 있습니다.

* **테스트**
  * 서비스 로직이 신규 활성-리뷰 조회 API를 사용하도록 테스트들이 갱신되었습니다. 집계·재계산 관련 테스트 데이터와 기대값이 이에 맞게 조정되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->