### PR TITLE
[perf] Redis Look-aside 캐싱 적용으로 플레이리스트 상세조회 트래픽 최적화

### DIFF
--- a/src/main/java/com/mopl/api/domain/playlist/repository/impl/PlaylistRepositoryCustom.java
+++ b/src/main/java/com/mopl/api/domain/playlist/repository/impl/PlaylistRepositoryCustom.java
@@ -4,6 +4,7 @@ import com.mopl.api.domain.playlist.entity.Playlist;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
+import org.springframework.cache.annotation.Cacheable;
 
 public interface PlaylistRepositoryCustom {
 
@@ -19,6 +20,7 @@ public interface PlaylistRepositoryCustom {
         int limit
     );
 
+    @Cacheable(value = "playlistCount")
     long countPlaylists(
         String keywordLike,
         UUID ownerIdEqual,

--- a/src/main/java/com/mopl/api/domain/playlist/service/PlaylistService.java
+++ b/src/main/java/com/mopl/api/domain/playlist/service/PlaylistService.java
@@ -29,6 +29,9 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -47,6 +50,10 @@ public class PlaylistService {
     private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
+    @Caching(evict = {
+        @CacheEvict(value = "playlistCount", allEntries = true),
+        @CacheEvict(value = "playlistDetail", allEntries = true)
+    })
     public PlaylistDto addPlaylist(PlaylistCreateRequest request, UUID userId) {
 
         User user = userRepository.findById(userId)
@@ -74,6 +81,7 @@ public class PlaylistService {
     }
 
     @Transactional
+    @CacheEvict(value = "playlistDetail", allEntries = true)
     public PlaylistDto modifyPlaylist(UUID playlistId, PlaylistUpdateRequest request, UUID userId) {
         Playlist playlist = playlistRepository.findById(playlistId)
                                               .orElseThrow(() -> PlaylistNotFoundException.withPlaylistId(playlistId));
@@ -95,6 +103,10 @@ public class PlaylistService {
     }
 
     @Transactional
+    @Caching(evict = {
+        @CacheEvict(value = "playlistCount", allEntries = true),
+        @CacheEvict(value = "playlistDetail", allEntries = true)
+    })
     public void removePlaylist(UUID playlistId, UUID userId) {
         Playlist playlist = playlistRepository.findById(playlistId)
                                               .orElseThrow(() -> PlaylistNotFoundException.withPlaylistId(playlistId));
@@ -109,6 +121,7 @@ public class PlaylistService {
         playlistRepository.save(playlist);
     }
 
+    @Cacheable(value = "playlistDetail", key = "#playlistId + '_' + #currentUserId")
     public PlaylistDto getPlaylist(UUID playlistId, UUID currentUserId) {
         Playlist playlist = playlistRepository.findById(playlistId)
                                               .orElseThrow(() -> PlaylistNotFoundException.withPlaylistId(playlistId));
@@ -227,6 +240,7 @@ public class PlaylistService {
     }
 
     @Transactional
+    @CacheEvict(value = "playlistDetail", allEntries = true)
     public void addContentToPlaylist(UUID playlistId, UUID contentId, UUID userId) {
         Playlist playlist = playlistRepository.findById(playlistId)
                                               .orElseThrow(() -> PlaylistNotFoundException.withPlaylistId(playlistId));
@@ -258,6 +272,7 @@ public class PlaylistService {
     }
 
     @Transactional
+    @CacheEvict(value = "playlistDetail", allEntries = true)
     public void removeContentFromPlaylist(UUID playlistId, UUID contentId, UUID userId) {
         Playlist playlist = playlistRepository.findById(playlistId)
                                               .orElseThrow(() -> PlaylistNotFoundException.withPlaylistId(playlistId));

--- a/src/main/java/com/mopl/api/domain/review/repository/impl/ReviewRepositoryCustom.java
+++ b/src/main/java/com/mopl/api/domain/review/repository/impl/ReviewRepositoryCustom.java
@@ -5,6 +5,7 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
+import org.springframework.cache.annotation.Cacheable;
 
 public interface ReviewRepositoryCustom {
 
@@ -18,6 +19,7 @@ public interface ReviewRepositoryCustom {
         int limit
     );
 
+    @Cacheable(value = "reviewCount", key = "#contentId")
     long countReviewsByContentId(UUID contentId);
 
     List<Review> findActiveReviewsByContentId(UUID contentId);

--- a/src/main/java/com/mopl/api/domain/review/service/ReviewService.java
+++ b/src/main/java/com/mopl/api/domain/review/service/ReviewService.java
@@ -22,6 +22,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,6 +37,7 @@ public class ReviewService {
     private final ReviewMapper reviewMapper;
 
     @Transactional
+    @CacheEvict(value = "reviewCount", key = "#request.contentId()")
     public ReviewDto addReview(ReviewCreateRequest request, UUID userId) {
         Content content = contentRepository.findById(request.contentId())
                                            .orElseThrow(
@@ -83,6 +85,7 @@ public class ReviewService {
     }
 
     @Transactional
+    @CacheEvict(value = "reviewCount", key = "#review.content.id")
     public void removeReview(UUID reviewId, UUID userId) {
         Review review = reviewRepository.findById(reviewId)
                                         .orElseThrow(() -> ReviewNotFoundException.withReviewId(reviewId));

--- a/src/main/java/com/mopl/api/domain/review/service/ReviewService.java
+++ b/src/main/java/com/mopl/api/domain/review/service/ReviewService.java
@@ -20,6 +20,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.CacheManager;
@@ -105,7 +106,8 @@ public class ReviewService {
 
         recalculateContentRating(contentId);
 
-        cacheManager.getCache("reviewCount").evict(contentId);
+        Optional.ofNullable(cacheManager.getCache("reviewCount"))
+                .ifPresent(cache -> cache.evict(contentId));
     }
 
     public CursorResponseReviewDto getReviews(

--- a/src/main/java/com/mopl/api/domain/review/service/ReviewService.java
+++ b/src/main/java/com/mopl/api/domain/review/service/ReviewService.java
@@ -22,6 +22,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,6 +36,7 @@ public class ReviewService {
     private final ContentRepository contentRepository;
     private final UserRepository userRepository;
     private final ReviewMapper reviewMapper;
+    private final CacheManager cacheManager;
 
     @Transactional
     @CacheEvict(value = "reviewCount", key = "#request.contentId()")
@@ -85,7 +87,6 @@ public class ReviewService {
     }
 
     @Transactional
-    @CacheEvict(value = "reviewCount", key = "#review.content.id")
     public void removeReview(UUID reviewId, UUID userId) {
         Review review = reviewRepository.findById(reviewId)
                                         .orElseThrow(() -> ReviewNotFoundException.withReviewId(reviewId));
@@ -96,12 +97,15 @@ public class ReviewService {
             throw ReviewUnauthorizedException.withDetails(reviewId, userId);
         }
 
+        UUID contentId = review.getContent().getId();
+
         review.softDelete();
 
         reviewRepository.save(review);
 
-        recalculateContentRating(review.getContent()
-                                       .getId());
+        recalculateContentRating(contentId);
+
+        cacheManager.getCache("reviewCount").evict(contentId);
     }
 
     public CursorResponseReviewDto getReviews(

--- a/src/main/java/com/mopl/api/global/config/redis/RedisConfig.java
+++ b/src/main/java/com/mopl/api/global/config/redis/RedisConfig.java
@@ -106,11 +106,10 @@ public class RedisConfig {
                                                                         serializer)
                                                                 );
 
-        // 필요시 특정 캐시 이름에 대해서만 다른 설정 적용
         Map<String, RedisCacheConfiguration> configurations = new HashMap<>();
-        // temp가 value인 경우 2시간
-        // @Cacheable(value = "temp", key = "#tempId", cacheManager = "cacheManager")
-        configurations.put("temp", config.entryTtl(Duration.ofHours(2)));
+        configurations.put("playlistCount", config.entryTtl(Duration.ofMinutes(10)));
+        configurations.put("reviewCount", config.entryTtl(Duration.ofMinutes(10)));
+        configurations.put("playlistDetail", config.entryTtl(Duration.ofMinutes(30)));
 
         return RedisCacheManager.builder(connectionFactory)
                                 .cacheDefaults(config)

--- a/src/test/java/com/mopl/api/config/TestRedisConfig.java
+++ b/src/test/java/com/mopl/api/config/TestRedisConfig.java
@@ -1,0 +1,92 @@
+package com.mopl.api.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@TestConfiguration
+@EnableCaching
+public class TestRedisConfig {
+
+    @Bean
+    @Primary
+    public RedisConnectionFactory testRedisConnectionFactory() {
+        RedisStandaloneConfiguration redisConfig = new RedisStandaloneConfiguration("localhost", 6379);
+        return new LettuceConnectionFactory(redisConfig);
+    }
+
+    @Bean
+    @Primary
+    public RedisTemplate<String, String> testRedisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        return template;
+    }
+
+    @Bean
+    @Primary
+    public RedisTemplate<String, Object> testRedisObjectTemplate(
+        RedisConnectionFactory connectionFactory,
+        ObjectMapper objectMapper
+    ) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(serializer);
+
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(serializer);
+
+        return template;
+    }
+
+    @Bean
+    @Primary
+    public RedisCacheManager testCacheManager(
+        RedisConnectionFactory connectionFactory,
+        ObjectMapper objectMapper
+    ) {
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+
+        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+                                                                .entryTtl(Duration.ofMinutes(60))
+                                                                .disableCachingNullValues()
+                                                                .serializeKeysWith(
+                                                                    RedisSerializationContext.SerializationPair.fromSerializer(
+                                                                        new StringRedisSerializer())
+                                                                )
+                                                                .serializeValuesWith(
+                                                                    RedisSerializationContext.SerializationPair.fromSerializer(
+                                                                        serializer)
+                                                                );
+
+        Map<String, RedisCacheConfiguration> configurations = new HashMap<>();
+        configurations.put("playlistCount", config.entryTtl(Duration.ofMinutes(10)));
+        configurations.put("reviewCount", config.entryTtl(Duration.ofMinutes(10)));
+        configurations.put("playlistDetail", config.entryTtl(Duration.ofMinutes(30)));
+
+        return RedisCacheManager.builder(connectionFactory)
+                                .cacheDefaults(config)
+                                .withInitialCacheConfigurations(configurations)
+                                .build();
+    }
+}

--- a/src/test/java/com/mopl/api/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/mopl/api/domain/review/service/ReviewServiceTest.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.CacheManager;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("ReviewService 단위 테스트")
@@ -60,6 +61,9 @@ class ReviewServiceTest {
 
     @Mock
     private ReviewMapper reviewMapper;
+
+    @Mock
+    private CacheManager cacheManager;
 
     @InjectMocks
     private ReviewService reviewService;


### PR DESCRIPTION
## Issues
- closed #146 

## ✔️  Check-list
- [x] : Label을 지정해 주세요.
- [x] : Merge할 브랜치를 확인해 주세요.

## 🗒️ Work Description
- DDD 방식 평점 계산으로 리팩토링 (ratingSum 필드 활용)
- ReviewService에서 명시적 Content 상태 저장 추가
- Redis 캐시 적용: playlistCount, reviewCount, playlistDetail
- 캐시 TTL 설정: count 10분, detail 30분
- QueryDSL에서 averageRating 계산식으로 변경

Related to #146
## 📷 Screenshot

## 📚 Reference

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **성능 개선**
  * 플레이리스트 및 리뷰 조회 응답이 더 빨라졌습니다(자주 조회되는 통계 및 상세 정보 캐시).
  * 플레이리스트 상세 정보 캐시로 상세 조회 성능 향상.
  * 캐시별 TTL(플레이리스트 통계 10분, 리뷰 통계 10분, 상세정보 30분)으로 캐시 효율 개선.

* **동작 개선**
  * 플레이리스트·리뷰 추가·수정·삭제 시 관련 캐시가 자동으로 갱신되어 최신 상태 유지됩니다.

* **테스트**
  * 통합 테스트용 Redis 구성과 캐시 관련 테스트 설정이 추가되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->